### PR TITLE
Bump dora to 0.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,4 +42,4 @@ uuid = { version = "1.0", features = ["v4"] }
 rand = "0.8"
 
 # Dora - robotics framework for voice chat architecture
-dora-node-api = "0.4.0"
+dora-node-api = "0.4.1"

--- a/libs/dora-common/pyproject.toml
+++ b/libs/dora-common/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Common utilities for Dora nodes"
 requires-python = ">=3.8"
 dependencies = [
-    "dora-rs>=0.3.7",
+    "dora-rs>=0.4.1",
     "pyarrow>=10.0.0",
 ]
 

--- a/models/setup-local-models/install_all_packages.sh
+++ b/models/setup-local-models/install_all_packages.sh
@@ -104,7 +104,7 @@ fi
 
 # Install Dora CLI
 print_header "Installing Dora CLI"
-DORA_VERSION="0.3.12"
+DORA_VERSION="0.4.1"
 
 # Remove all non-cargo dora installations (except nix symlinks)
 dora_locations=$(type -a dora 2>/dev/null | awk '{print $NF}' || true)

--- a/node-hub/dora-asr/pyproject.toml
+++ b/node-hub/dora-asr/pyproject.toml
@@ -8,7 +8,7 @@ description = "Multi-engine ASR node for Dora with Whisper and FunASR support"
 readme = "README.md"
 
 dependencies = [
-    "dora-rs>=0.3.7",
+    "dora-rs>=0.4.1",
     "numpy>=1.21.0,<2.0",  # CRITICAL: Must be 1.x (1.26.4 recommended) for compatibility
     "scipy>=1.11.0,<1.12.0",  # Required by librosa, use 1.11.4 for Python 3.12
     "pyarrow>=10.0.0",

--- a/node-hub/dora-conference-bridge/Cargo.toml
+++ b/node-hub/dora-conference-bridge/Cargo.toml
@@ -11,7 +11,7 @@ name = "dora-conference-bridge"
 path = "src/main.rs"
 
 [dependencies]
-dora-node-api = "0.4.0"
+dora-node-api = "0.4.1"
 eyre = "0.6"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/node-hub/dora-conference-controller/Cargo.toml
+++ b/node-hub/dora-conference-controller/Cargo.toml
@@ -15,8 +15,8 @@ name = "dora-conference-controller"
 path = "src/main.rs"
 
 [dependencies]
-dora-node-api = "0.4.0"
-dora-core = "0.4.0"
+dora-node-api = "0.4.1"
+dora-core = "0.4.1"
 eyre = "0.6"
 futures = "0.3"
 serde = { version = "1.0", features = ["derive"] }

--- a/node-hub/dora-conference-controller/dora-conference-bridge/Cargo.toml
+++ b/node-hub/dora-conference-controller/dora-conference-bridge/Cargo.toml
@@ -9,7 +9,7 @@ name = "dora-conference-bridge"
 path = "src/main.rs"
 
 [dependencies]
-dora-node-api = "0.4.0"
+dora-node-api = "0.4.1"
 eyre = "0.6"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/node-hub/dora-maas-client/Cargo.toml
+++ b/node-hub/dora-maas-client/Cargo.toml
@@ -20,12 +20,16 @@ path = "src/main.rs"
 async-trait = "0.1"
 bytes = "1.0"
 chrono = "0.4.31"
-dora-node-api = { version = "0.4.0", features = ["tracing"] }
+dora-node-api = { version = "0.4.1", features = ["tracing"] }
 eyre = "0.6.8"
 figment = { version = "0.10.0", features = ["env", "json", "toml", "yaml"] }
 futures = "0.3.31"
 outfox-openai = { version = "0.2.0", git = "https://github.com/outfox-ai/outfox.git" }
-reqwest = { version = "0.12.22", default-features = false, features = ["json", "stream", "rustls-tls"] }
+reqwest = { version = "0.12.22", default-features = false, features = [
+    "json",
+    "stream",
+    "rustls-tls",
+] }
 reqwest-eventsource = "0.6.0"
 rmcp = { version = "0.3.2", git = "https://github.com/modelcontextprotocol/rust-sdk.git", rev = "fbc7ab7", features = [
     "client",

--- a/node-hub/dora-primespeech/pyproject.toml
+++ b/node-hub/dora-primespeech/pyproject.toml
@@ -5,7 +5,7 @@ description = "Dora node for GPT-SoVITS text-to-speech synthesis"
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
-    "dora-rs>=0.3.7",
+    "dora-rs>=0.4.1",
     "numpy>=1.21.0,<2.0",  # CRITICAL: Must be 1.x (1.26.4 recommended) for scipy compatibility
     "scipy>=1.11.0,<1.12.0",  # CRITICAL: 1.11.4 for Python 3.12 compatibility
     "torchmetrics==1.0.0",  # CRITICAL: Exact version to avoid scipy conflicts

--- a/node-hub/dora-primespeech/requirements_simple.txt
+++ b/node-hub/dora-primespeech/requirements_simple.txt
@@ -1,7 +1,7 @@
 # Simplified requirements for dora-primespeech
 # Core dependencies only - for full MoYoYo TTS, use: pip install -e .
 
-dora-rs>=0.3.7
+dora-rs>=0.4.1
 numpy>=1.21.0
 pyarrow>=10.0.0
 torch>=2.0.0

--- a/node-hub/dora-speechmonitor/pyproject.toml
+++ b/node-hub/dora-speechmonitor/pyproject.toml
@@ -8,7 +8,7 @@ description = "Real-time speech monitoring node with Silero VAD for Dora"
 readme = "README.md"
 
 dependencies = [
-    "dora-rs>=0.3.7",
+    "dora-rs>=0.4.1",
     "numpy>=1.21.0,<2.0",  # CRITICAL: Must be 1.x (1.26.4 recommended)
     "scipy>=1.11.0",  # Updated to support newer versions
     "pyarrow>=10.0.0",

--- a/node-hub/dora-text-segmenter/pyproject.toml
+++ b/node-hub/dora-text-segmenter/pyproject.toml
@@ -2,7 +2,7 @@
 name = "dora-text-segmenter"
 version = "0.1.0"
 dependencies = [
-    "dora-rs>=0.3.7",
+    "dora-rs>=0.4.1",
     "pyarrow>=10.0.0",
     "numpy>=1.21.0,<2.0",  # CRITICAL: Must be 1.x (1.26.4 recommended)
 ]


### PR DESCRIPTION
This PR fixes the deadlock that was blocking dora from stopping as well as bump dora version on all nodes making sure there is no conflict.

## To fix your environment just run:


```bash
dora destroy
conda activate mofa-studio
./install_all_packages.sh
dora up
```

That's it!