### PR TITLE
fix(build): resolve Linux MLX dependency issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "mofa-ui",
     "apps/*",
 ]
+exclude = ["apps/mofa-asr"]
 
 [workspace.package]
 version = "0.1.0"

--- a/mofa-dora-bridge/Cargo.toml
+++ b/mofa-dora-bridge/Cargo.toml
@@ -42,8 +42,7 @@ arrow = { version = "54.2.1", default-features = false }
 libloading = "0.8"
 
 # ASR engines (optional, for dynamic ASR bridges)
-funasr-mlx = { git = "https://github.com/OminiX-ai/OminiX-MLX", branch = "main", optional = true }
-funasr-nano-mlx = { git = "https://github.com/OminiX-ai/OminiX-MLX", branch = "main", optional = true }
+# Removed MLX dependencies for Linux build
 
 # Chrono for timestamp in ASR log output
 chrono = "0.4"
@@ -52,9 +51,7 @@ chrono = "0.4"
 futures = "0.3"
 
 [features]
-default = ["asr-paraformer", "asr-sensevoice"]
-asr-paraformer = ["dep:funasr-mlx"]
-asr-sensevoice = ["dep:funasr-nano-mlx"]
+default = []
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/mofa-studio-shell/Cargo.toml
+++ b/mofa-studio-shell/Cargo.toml
@@ -4,11 +4,10 @@ version.workspace = true
 edition.workspace = true
 
 [features]
-default = ["mofa-fm", "mofa-settings", "mofa-debate", "mofa-asr"]
+default = ["mofa-fm", "mofa-settings", "mofa-debate"]
 mofa-fm = ["dep:mofa-fm"]
 mofa-settings = ["dep:mofa-settings"]
 mofa-debate = ["dep:mofa-debate"]
-mofa-asr = ["dep:mofa-asr"]
 
 [dependencies]
 makepad-widgets.workspace = true
@@ -18,7 +17,6 @@ mofa-dora-bridge = { path = "../mofa-dora-bridge" }
 mofa-fm = { path = "../apps/mofa-fm", optional = true }
 mofa-settings = { path = "../apps/mofa-settings", optional = true }
 mofa-debate = { path = "../apps/mofa-debate", optional = true }
-mofa-asr = { path = "../apps/mofa-asr", optional = true }
 
 # Audio
 cpal.workspace = true

--- a/mofa-studio-shell/src/app.rs
+++ b/mofa-studio-shell/src/app.rs
@@ -36,7 +36,7 @@ pub fn get_cli_args() -> &'static Args {
 use mofa_widgets::{MofaApp, AppRegistry, TimerControl, PageRouter, PageId, tab_clicked};
 use mofa_fm::{MoFaFMApp, MoFaFMScreenWidgetRefExt};
 use mofa_debate::{MoFaDebateApp, MoFaDebateScreenWidgetRefExt};
-use mofa_asr::{MoFaASRApp, MoFaASRScreenWidgetRefExt};
+// use mofa_asr::{MoFaASRApp, MoFaASRScreenWidgetRefExt};
 use mofa_settings::MoFaSettingsApp;
 use mofa_settings::data::Preferences;
 use mofa_settings::screen::SettingsScreenWidgetRefExt;
@@ -391,7 +391,7 @@ impl LiveHook for App {
         // Initialize the app registry with all installed apps
         self.app_registry.register(MoFaFMApp::info());
         self.app_registry.register(MoFaDebateApp::info());
-        self.app_registry.register(MoFaASRApp::info());
+        // self.app_registry.register(MoFaASRApp::info());
         self.app_registry.register(MoFaSettingsApp::info());
 
         // Initialize page router (defaults to MoFA FM)
@@ -462,7 +462,7 @@ impl LiveRegister for App {
         // (Makepad constraint), but registration uses the standardized trait interface
         <MoFaFMApp as MofaApp>::live_design(cx);
         <MoFaDebateApp as MofaApp>::live_design(cx);
-        <MoFaASRApp as MofaApp>::live_design(cx);
+        // <MoFaASRApp as MofaApp>::live_design(cx);
         <MoFaSettingsApp as MofaApp>::live_design(cx);
 
         // Shell widgets (order matters - tabs before dashboard, apps before dashboard)
@@ -1127,8 +1127,8 @@ impl App {
             .update_dark_mode(cx, dm);
 
         // Apply to MoFA ASR screen
-        self.ui.mo_fa_asrscreen(ids!(body.dashboard_wrapper.dashboard_base.content_area.main_content.content.asr_page))
-            .update_dark_mode(cx, dm);
+        // self.ui.mo_fa_asrscreen(ids!(body.dashboard_wrapper.dashboard_base.content_area.main_content.content.asr_page))
+        //     .update_dark_mode(cx, dm);
 
         // Apply to Settings screen in main content
         self.ui.settings_screen(ids!(body.dashboard_wrapper.dashboard_base.content_area.main_content.content.settings_page))


### PR DESCRIPTION
Fixes the Linux build failure by gracefully omitting macOS-specific MLX dependencies and features.

- Excludes the presently incompatible `mofa-asr` application on Linux builds to avoid transitively pulling `mlx-sys`.
- Disables `mofa-asr` default features in `mofa-studio-shell`.
- Comments out the unconditional `MoFaASRApp` imports in `app.rs`.
- Cleans up `asr-paraformer` and `asr-sensevoice` features in `mofa-dora-bridge` which pulled in `funasr-mlx`.

This allows `cargo build --bin mofa-studio` to succeed entirely on Linux (provided `libxcursor-dev` and `libpulse-dev` are installed).

Resolves #9