### PR TITLE
fix(asr): pass system API keys to dynamically spawned ASR nodes

### DIFF
--- a/apps/mofa-asr/src/dora_integration.rs
+++ b/apps/mofa-asr/src/dora_integration.rs
@@ -56,7 +56,7 @@ impl AsrProcessManager {
         }
     }
 
-    fn spawn_engine(&mut self, engine: AsrEngineId) {
+    fn spawn_engine(&mut self, engine: AsrEngineId, env_vars: &std::collections::HashMap<String, String>) {
         // Kill existing process first
         self.kill_engine(engine);
 
@@ -72,12 +72,14 @@ impl AsrProcessManager {
             node_id
         );
 
-        match std::process::Command::new(&bin_path)
-            .arg("--name")
-            .arg(node_id)
-            .stdout(std::process::Stdio::inherit())
-            .stderr(std::process::Stdio::inherit())
-            .spawn()
+        let mut cmd = std::process::Command::new(&bin_path);
+        cmd.arg("--name")
+           .arg(node_id)
+           .envs(env_vars)
+           .stdout(std::process::Stdio::inherit())
+           .stderr(std::process::Stdio::inherit());
+
+        match cmd.spawn()
         {
             Ok(child) => {
                 log::info!(
@@ -165,7 +167,10 @@ pub enum DoraCommand {
     /// Force stop the dataflow immediately (0s grace period)
     ForceStopDataflow,
     /// Connect an ASR engine (spawn child process)
-    ConnectAsrEngine { engine: AsrEngineId },
+    ConnectAsrEngine { 
+        engine: AsrEngineId,
+        env_vars: std::collections::HashMap<String, String>,
+    },
     /// Disconnect an ASR engine (kill child process)
     DisconnectAsrEngine { engine: AsrEngineId },
     /// Start mic recording
@@ -297,8 +302,8 @@ impl DoraIntegration {
     }
 
     /// Connect an ASR engine (spawn child process)
-    pub fn connect_asr_engine(&self, engine: AsrEngineId) -> bool {
-        self.send_command(DoraCommand::ConnectAsrEngine { engine })
+    pub fn connect_asr_engine(&self, engine: AsrEngineId, env_vars: std::collections::HashMap<String, String>) -> bool {
+        self.send_command(DoraCommand::ConnectAsrEngine { engine, env_vars })
     }
 
     /// Disconnect an ASR engine (kill child process)
@@ -421,9 +426,9 @@ impl DoraIntegration {
                         let _ = event_tx.send(DoraEvent::DataflowStopped);
                     }
 
-                    DoraCommand::ConnectAsrEngine { engine } => {
+                    DoraCommand::ConnectAsrEngine { engine, env_vars } => {
                         log::info!("Connecting ASR engine: {:?}", engine);
-                        asr_processes.spawn_engine(engine);
+                        asr_processes.spawn_engine(engine, &env_vars);
                     }
 
                     DoraCommand::DisconnectAsrEngine { engine } => {

--- a/apps/mofa-asr/src/screen/mod.rs
+++ b/apps/mofa-asr/src/screen/mod.rs
@@ -10,6 +10,7 @@ mod log_panel;
 use makepad_widgets::*;
 use mofa_ui::{MofaHeroWidgetExt, MofaHeroAction, ConnectionStatus, AudioManager};
 use mofa_ui::{LedMeterWidgetExt, MicButtonWidgetExt, AecButtonWidgetExt};
+use mofa_settings::data::Preferences;
 use crate::dora_integration::{AsrEngineId, DoraIntegration, DoraEvent};
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -493,7 +494,7 @@ impl MoFaASRScreen {
 
         self.init_dora(cx);
 
-        let mut env_vars = HashMap::new();
+        let mut env_vars = self.load_api_keys_from_preferences();
         env_vars.insert("MIN_AUDIO_DURATION".to_string(), self.settings.min_audio_duration.to_string());
         env_vars.insert("MAX_AUDIO_DURATION".to_string(), self.settings.max_audio_duration.to_string());
 
@@ -562,7 +563,8 @@ impl MoFaASRScreen {
 
         if let Some(ref dora) = self.dora_integration {
             if now_active {
-                dora.connect_asr_engine(engine);
+                let env_vars = self.load_api_keys_from_preferences();
+                dora.connect_asr_engine(engine, env_vars);
                 self.add_log(cx, &format!("[INFO] [App] Starting {:?} engine", engine));
             } else {
                 dora.disconnect_asr_engine(engine);
@@ -866,6 +868,38 @@ impl MoFaASRScreen {
         });
 
         self.view.redraw(cx);
+    }
+
+    /// Load API keys from preferences
+    pub(super) fn load_api_keys_from_preferences(&self) -> HashMap<String, String> {
+        let mut env_vars = HashMap::new();
+
+        let prefs = Preferences::load();
+
+        for provider in &prefs.providers {
+            if let Some(ref api_key) = provider.api_key {
+                if !api_key.is_empty() {
+                    let env_var_name = match provider.id.as_str() {
+                        "openai" => "OPENAI_API_KEY".to_string(),
+                        "deepseek" => "DEEPSEEK_API_KEY".to_string(),
+                        "alibaba_cloud" => "ALIBABA_CLOUD_API_KEY".to_string(),
+                        "nvidia" => "NVIDIA_API_KEY".to_string(),
+                        id => format!("{}_API_KEY", id.to_uppercase().replace('-', "_")),
+                    };
+                    env_vars.insert(env_var_name, api_key.clone());
+                }
+            }
+        }
+
+        if let Some(provider) = prefs.get_provider("alibaba_cloud") {
+            if let Some(ref api_key) = provider.api_key {
+                if !api_key.is_empty() {
+                    env_vars.insert("DASHSCOPE_API_KEY".to_string(), api_key.clone());
+                }
+            }
+        }
+
+        env_vars
     }
 }
 


### PR DESCRIPTION
Fixes issue #8  

## Summary
API keys configured in mofa-settings were not being propagated to Dora dataflow nodes and dynamically spawned ASR engine processes in mofa-asr. This caused LLM-backed features (e.g. chat participants in mofa-fm/mofa-debate) to fail immediately with:

```
[No API key provided. Set OPENAI_API_KEY or provide in request.]
```

## Root Cause
Two separate code paths were missing API key injection:

1. Dataflow launch — handle_start() called start_dataflow_with_env() without loading keys from mofa-settings, so the entire Dora runtime started with empty API key environment variables.
2. Dynamic engine spawn — AsrProcessManager::spawn_engine() used a bare std::process::Command::new() with no .envs(...) call, meaning dynamically toggled ASR child processes (e.g. Paraformer, SenseVoice, StepAudio2) could not access API keys set in the UI after app launch.

## How It Works
The voice-chat.yml dataflow files use shell interpolation syntax (e.g. ${OPENAI_API_KEY:-}) to read API keys from the environment at launch time. By calling start_dataflow_with_env() with the keys from mofa-settings, those variables are now correctly available to every node in the Dora dataflow — including dora-maas-client nodes that call LLM APIs.

## Testing

1. Configure an OpenAI API key in **Settings** (`mofa-settings`)
2. Build and run `mofa-fm` or `mofa-debate`
3. Start a voice session
4. Confirm LLM participants respond normally — no `[No API key provided.]` error in the chat panel

For `mofa-asr`: Start the dataflow, toggle any engine ON, and verify it receives audio without API key errors in the logs.


## Related Pattern
This fix aligns mofa-asr with the existing, working pattern in mofa-fm ( load_api_keys_from_preferences ), ensuring consistency across all MoFA applications.