### PR TITLE
fix(safety): replace static mut variables with atomic types in mofa-fm screen

### DIFF
--- a/apps/mofa-fm/src/screen/mod.rs
+++ b/apps/mofa-fm/src/screen/mod.rs
@@ -25,6 +25,7 @@ use mofa_widgets::{StateChangeListener, TimerControl};
 use mofa_ui::{LedMeterWidgetExt, MicButtonWidgetExt, AecButtonWidgetExt};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
 /// Data preloaded in background thread
 #[derive(Default)]
@@ -249,25 +250,21 @@ impl Widget for MoFaFMScreen {
         }
 
         // Debug: Log every event type once
-        static mut LOGGED_TIMER: bool = false;
-        unsafe {
-            if !LOGGED_TIMER {
-                if let Event::Timer(_) = event {
-                    ::log::info!("Received Timer event");
-                    LOGGED_TIMER = true;
-                }
+        static LOGGED_TIMER: AtomicBool = AtomicBool::new(false);
+        if !LOGGED_TIMER.load(Ordering::Relaxed) {
+            if let Event::Timer(_) = event {
+                ::log::info!("Received Timer event");
+                LOGGED_TIMER.store(true, Ordering::Relaxed);
             }
         }
 
         // Handle audio timer for mic level updates, log polling, and buffer status
         if self.audio_timer.is_event(event).is_some() {
             // Debug: log timer firing
-            static mut TIMER_COUNT: u32 = 0;
-            unsafe {
-                TIMER_COUNT += 1;
-                if TIMER_COUNT == 1 {
-                    ::log::info!("Audio timer first fire");
-                }
+            static TIMER_COUNT: AtomicU32 = AtomicU32::new(0);
+            let count = TIMER_COUNT.fetch_add(1, Ordering::Relaxed) + 1;
+            if count == 1 {
+                ::log::info!("Audio timer first fire");
             }
             self.update_mic_level(cx);
             // Poll Rust logs (50ms interval is fine for log updates)


### PR DESCRIPTION
## Summary

Fixes data race vulnerability in `apps/mofa-fm/src/screen/mod.rs` where `static mut` variables were accessed from multiple threads without synchronization.

## Changes

- `apps/mofa-fm/src/screen/mod.rs`: Replace `static mut LOGGED_TIMER: bool` with `static LOGGED_TIMER: AtomicBool` and `static mut TIMER_COUNT: u32` with `static TIMER_COUNT: AtomicU32`. Replace unsafe blocks with atomic load/store/fetch_add operations.

## Test Plan

- [ ] Verify `cargo check` passes with no warnings
- [ ] Verify timer logging behavior is unchanged
- [ ] Verify no `unsafe` blocks remain for these statics

Closes #16