### PR TITLE
fix: restrict API key exposure and remove global env mutation in Debate/FM 

### DIFF
--- a/apps/mofa-debate/src/dora_integration.rs
+++ b/apps/mofa-debate/src/dora_integration.rs
@@ -210,10 +210,9 @@ impl DoraIntegration {
                     } => {
                         log::info!("Starting dataflow: {:?}", dataflow_path);
 
-                        // Set environment variables in both process env and controller
-                        for (key, value) in &env_vars {
+                        // Pass environment variables only to the dataflow controller
+                        for key in env_vars.keys() {
                             log::info!("Setting env var: {}=***", key);
-                            std::env::set_var(key, value);
                         }
 
                         match DataflowController::new(&dataflow_path) {

--- a/apps/mofa-debate/src/screen/dora_handlers.rs
+++ b/apps/mofa-debate/src/screen/dora_handlers.rs
@@ -529,38 +529,47 @@ impl MoFaDebateScreen {
         // to confirm the dataflow actually stopped
     }
 
-    /// Load API keys from preferences
-    /// Exports all provider API keys including custom providers
+    /// Load API keys from preferences using least-privilege rules.
+    ///
+    /// Rules:
+    /// - provider must be enabled
+    /// - provider must be on explicit allowlist
+    /// - custom providers are not auto-exported
     pub(super) fn load_api_keys_from_preferences(&self) -> HashMap<String, String> {
+        fn env_name_for_provider(provider_id: &str) -> Option<&'static str> {
+            match provider_id {
+                "openai" => Some("OPENAI_API_KEY"),
+                "deepseek" => Some("DEEPSEEK_API_KEY"),
+                "alibaba_cloud" => Some("ALIBABA_CLOUD_API_KEY"),
+                "nvidia" => Some("NVIDIA_API_KEY"),
+                _ => None,
+            }
+        }
+
         let mut env_vars = HashMap::new();
 
         // Load preferences
         let prefs = Preferences::load();
 
-        // Export API keys for ALL providers (built-in and custom)
-        for provider in &prefs.providers {
-            if let Some(ref api_key) = provider.api_key {
-                if !api_key.is_empty() {
-                    // Map provider ID to standard env var name
-                    let env_var_name = match provider.id.as_str() {
-                        "openai" => "OPENAI_API_KEY".to_string(),
-                        "deepseek" => "DEEPSEEK_API_KEY".to_string(),
-                        "alibaba_cloud" => "ALIBABA_CLOUD_API_KEY".to_string(),
-                        "nvidia" => "NVIDIA_API_KEY".to_string(),
-                        // For custom providers, use uppercase ID + _API_KEY
-                        id => format!("{}_API_KEY", id.to_uppercase().replace('-', "_")),
-                    };
-                    env_vars.insert(env_var_name, api_key.clone());
-                }
-            }
-        }
+        for provider in prefs.providers.iter().filter(|p| p.enabled) {
+            let Some(env_var_name) = env_name_for_provider(provider.id.as_str()) else {
+                continue;
+            };
 
-        // Also export DASHSCOPE_API_KEY for backwards compatibility with alibaba_cloud
-        if let Some(provider) = prefs.get_provider("alibaba_cloud") {
-            if let Some(ref api_key) = provider.api_key {
-                if !api_key.is_empty() {
-                    env_vars.insert("DASHSCOPE_API_KEY".to_string(), api_key.clone());
-                }
+            let Some(api_key) = provider.api_key.as_ref() else {
+                continue;
+            };
+
+            let trimmed = api_key.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+
+            env_vars.insert(env_var_name.to_string(), trimmed.to_string());
+
+            // Backward-compat alias only if Alibaba key is actively exported
+            if provider.id == "alibaba_cloud" {
+                env_vars.insert("DASHSCOPE_API_KEY".to_string(), trimmed.to_string());
             }
         }
 

--- a/apps/mofa-fm/src/dora_integration.rs
+++ b/apps/mofa-fm/src/dora_integration.rs
@@ -230,10 +230,9 @@ impl DoraIntegration {
                     } => {
                         log::info!("Starting dataflow: {:?}", dataflow_path);
 
-                        // Set environment variables in both process env and controller
-                        for (key, value) in &env_vars {
+                        // Pass environment variables only to the dataflow controller
+                        for key in env_vars.keys() {
                             log::info!("Setting env var: {}=***", key);
-                            std::env::set_var(key, value);
                         }
 
                         match DataflowController::new(&dataflow_path) {

--- a/apps/mofa-fm/src/screen/dora_handlers.rs
+++ b/apps/mofa-fm/src/screen/dora_handlers.rs
@@ -494,38 +494,47 @@ impl MoFaFMScreen {
         // to confirm the dataflow actually stopped
     }
 
-    /// Load API keys from preferences
-    /// Exports all provider API keys including custom providers
+    /// Load API keys from preferences using least-privilege rules.
+    ///
+    /// Rules:
+    /// - provider must be enabled
+    /// - provider must be on explicit allowlist
+    /// - custom providers are not auto-exported
     pub(super) fn load_api_keys_from_preferences(&self) -> HashMap<String, String> {
+        fn env_name_for_provider(provider_id: &str) -> Option<&'static str> {
+            match provider_id {
+                "openai" => Some("OPENAI_API_KEY"),
+                "deepseek" => Some("DEEPSEEK_API_KEY"),
+                "alibaba_cloud" => Some("ALIBABA_CLOUD_API_KEY"),
+                "nvidia" => Some("NVIDIA_API_KEY"),
+                _ => None,
+            }
+        }
+
         let mut env_vars = HashMap::new();
 
         // Load preferences
         let prefs = Preferences::load();
 
-        // Export API keys for ALL providers (built-in and custom)
-        for provider in &prefs.providers {
-            if let Some(ref api_key) = provider.api_key {
-                if !api_key.is_empty() {
-                    // Map provider ID to standard env var name
-                    let env_var_name = match provider.id.as_str() {
-                        "openai" => "OPENAI_API_KEY".to_string(),
-                        "deepseek" => "DEEPSEEK_API_KEY".to_string(),
-                        "alibaba_cloud" => "ALIBABA_CLOUD_API_KEY".to_string(),
-                        "nvidia" => "NVIDIA_API_KEY".to_string(),
-                        // For custom providers, use uppercase ID + _API_KEY
-                        id => format!("{}_API_KEY", id.to_uppercase().replace('-', "_")),
-                    };
-                    env_vars.insert(env_var_name, api_key.clone());
-                }
-            }
-        }
+        for provider in prefs.providers.iter().filter(|p| p.enabled) {
+            let Some(env_var_name) = env_name_for_provider(provider.id.as_str()) else {
+                continue;
+            };
 
-        // Also export DASHSCOPE_API_KEY for backwards compatibility with alibaba_cloud
-        if let Some(provider) = prefs.get_provider("alibaba_cloud") {
-            if let Some(ref api_key) = provider.api_key {
-                if !api_key.is_empty() {
-                    env_vars.insert("DASHSCOPE_API_KEY".to_string(), api_key.clone());
-                }
+            let Some(api_key) = provider.api_key.as_ref() else {
+                continue;
+            };
+
+            let trimmed = api_key.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+
+            env_vars.insert(env_var_name.to_string(), trimmed.to_string());
+
+            // Backward-compat alias only if Alibaba key is actively exported
+            if provider.id == "alibaba_cloud" {
+                env_vars.insert("DASHSCOPE_API_KEY".to_string(), trimmed.to_string());
             }
         }
 


### PR DESCRIPTION
Fixes: #21 

**Files changed** : [mofa-debate/src/screen/dora_handlers.rs](https://github.com/mofa-org/mofa-studio/blob/main/apps/mofa-debate/src/screen/dora_handlers.rs), [mofa-fm/src/screen/dora_handlers.rs](https://github.com/mofa-org/mofa-studio/blob/main/apps/mofa-fm/src/screen/dora_handlers.rs), [mofa-debate/src/dora_integration.rs](https://github.com/mofa-org/mofa-studio/blob/main/apps/mofa-debate/src/dora_integration.rs), [apps/mofa-fm/src/dora_integration.rs](https://github.com/mofa-org/mofa-studio/blob/main/apps/mofa-fm/src/dora_integration.rs)

**Changes made**:

- Implemented least-privilege API key loading for Debate and FM flows.
- Added explicit allowlist mapping for supported providers (`OPENAI`, `DEEPSEEK`, `ALIBABA_CLOUD`, `NVIDIA`).
- Export API keys only when the provider is enabled and the key is non-empty.
- Removed automatic wildcard export of custom provider API keys.
- `DASHSCOPE_API_KEY` should be exported only when Alibaba Cloud is selected.
- Removed process-global environment mutation via `std::env::set_var`.
- Scoped environment variables to the dataflow execution using `controller.set_envs(...)`.

All changes are working as expected.