### PR TITLE
mofa-studio : fixed provided pannel bg issue in dark mode

### DIFF
--- a/apps/mofa-settings/src/providers_panel.rs
+++ b/apps/mofa-settings/src/providers_panel.rs
@@ -641,21 +641,9 @@ impl ProvidersPanel {
             ids!(scroll_view.list_container.nvidia_item),
         ];
 
-        let normal_color = if self.dark_mode {
-            vec4(0.12, 0.16, 0.23, 1.0)
-        } else {
-            vec4(1.0, 1.0, 1.0, 1.0)
-        };
-
-        let selected_color = if self.dark_mode {
-            vec4(0.12, 0.23, 0.37, 1.0)
-        } else {
-            vec4(0.86, 0.92, 1.0, 1.0)
-        };
-
         for item_id in &items {
             self.view.view(item_id.clone()).apply_over(cx, live!{
-                draw_bg: { color: (normal_color) }
+                draw_bg: { selected: 0.0, hover:0.0 }
             });
         }
 
@@ -684,22 +672,22 @@ impl ProvidersPanel {
         match selected {
             "openai" => {
                 self.view.view(ids!(scroll_view.list_container.openai_item)).apply_over(cx, live!{
-                    draw_bg: { color: (selected_color) }
+                    draw_bg: { selected: 1.0 }
                 });
             }
             "deepseek" => {
                 self.view.view(ids!(scroll_view.list_container.deepseek_item)).apply_over(cx, live!{
-                    draw_bg: { color: (selected_color) }
+                    draw_bg: { selected: 1.0 }
                 });
             }
             "alibaba_cloud" => {
                 self.view.view(ids!(scroll_view.list_container.alibaba_item)).apply_over(cx, live!{
-                    draw_bg: { color: (selected_color) }
+                    draw_bg: { selected: 1.0 }
                 });
             }
             "nvidia" => {
                 self.view.view(ids!(scroll_view.list_container.nvidia_item)).apply_over(cx, live!{
-                    draw_bg: { color: (selected_color) }
+                    draw_bg: { selected: 1.0 }
                 });
             }
             _ => {
@@ -766,10 +754,6 @@ impl ProvidersPanelRef {
             });
 
             // Color constants
-            let dark_normal = vec4(0.12, 0.16, 0.23, 1.0);
-            let light_normal = vec4(1.0, 1.0, 1.0, 1.0);
-            let dark_selected = vec4(0.12, 0.23, 0.37, 1.0);
-            let light_selected = vec4(0.86, 0.92, 1.0, 1.0);
             let dark_text = vec4(0.95, 0.96, 0.98, 1.0);
             let light_text = vec4(0.22, 0.25, 0.32, 1.0);
 
@@ -785,15 +769,19 @@ impl ProvidersPanelRef {
 
             for (provider_name, item_path, label_path) in items {
                 let is_selected = selected == Some(provider_name);
-                let bg_color = if is_selected {
-                    if is_dark { dark_selected } else { light_selected }
-                } else {
-                    if is_dark { dark_normal } else { light_normal }
-                };
-                let text_color = if is_dark { dark_text } else { light_text };
+                let selected_val = if is_selected { 1.0 } else { 0.0 };
 
-                inner.view.view(item_path).apply_over(cx, live!{ draw_bg: { color: (bg_color) } });
-                inner.view.label(label_path).apply_over(cx, live!{ draw_text: { color: (text_color) } });
+    inner.view.view(item_path).apply_over(cx, live!{
+        draw_bg: {
+            dark_mode: (dark_mode),
+            selected: (selected_val)
+        }
+    });
+    let text_color = if is_dark { dark_text } else { light_text };
+
+    inner.view.label(label_path).apply_over(cx, live!{
+        draw_text: { color: (text_color) }
+    });
             }
 
             // Custom header - matching sidebar style


### PR DESCRIPTION
## Issue  
Fixes #28  

---
### Problem
ProvidersPanel was manually overriding background colors using `draw_bg: { color: (...) }`,
while the shader already computes colors using instance variables (`dark_mode`, `hover`, `selected`).

This caused:
- Hover blending inconsistencies
- Dark mode repaint issues
- Conflicting visual state updates

### Solution
Removed manual background color overrides and restored proper shader-driven state updates.

Now:
- Rust sets only `dark_mode`, `hover`, and `selected`
- Shader computes final background color
- Hover animation and selection priority work correctly
- Dark mode transitions are consistent

### Result
Cleaner architecture and correct state-driven rendering.

---

## Screenshots / Before-After (if UI change)  

- **Before:** The issue caused incorrect/unexpected behavior as described in #28.  
- 
<img width="1767" height="996" alt="image" src="https://github.com/user-attachments/assets/c55e8b60-fa60-4c5b-adec-d607ea4b1215" />

- **After:** The behavior now works as expected and the issue is resolved.  
- 
<img width="1434" height="737" alt="image" src="https://github.com/user-attachments/assets/e5ed8eda-d867-4b3e-969e-4b4abfca90fc" />
_

---

## Testing  

- Tested the fix locally in development mode.  
- Verified that the issue described in #28 no longer occurs.  
- Ensured no related functionality was affected.  
- Confirmed the project builds and runs successfully after the changes.  