### PR TITLE
fix: clear previous provider highlight on new selection

### DIFF
--- a/apps/mofa-settings/src/providers_panel.rs
+++ b/apps/mofa-settings/src/providers_panel.rs
@@ -655,7 +655,7 @@ impl ProvidersPanel {
 
         for item_id in &items {
             self.view.view(item_id.clone()).apply_over(cx, live!{
-                draw_bg: { color: (normal_color) }
+                draw_bg: { selected: 0.0, hover: 0.0, color: (normal_color) }
             });
         }
 
@@ -684,22 +684,22 @@ impl ProvidersPanel {
         match selected {
             "openai" => {
                 self.view.view(ids!(scroll_view.list_container.openai_item)).apply_over(cx, live!{
-                    draw_bg: { color: (selected_color) }
+                    draw_bg: { selected: 1.0, color: (selected_color) }
                 });
             }
             "deepseek" => {
                 self.view.view(ids!(scroll_view.list_container.deepseek_item)).apply_over(cx, live!{
-                    draw_bg: { color: (selected_color) }
+                    draw_bg: { selected: 1.0, color: (selected_color) }
                 });
             }
             "alibaba_cloud" => {
                 self.view.view(ids!(scroll_view.list_container.alibaba_item)).apply_over(cx, live!{
-                    draw_bg: { color: (selected_color) }
+                    draw_bg: { selected: 1.0, color: (selected_color) }
                 });
             }
             "nvidia" => {
                 self.view.view(ids!(scroll_view.list_container.nvidia_item)).apply_over(cx, live!{
-                    draw_bg: { color: (selected_color) }
+                    draw_bg: { selected: 1.0, color: (selected_color) }
                 });
             }
             _ => {
@@ -790,9 +790,10 @@ impl ProvidersPanelRef {
                 } else {
                     if is_dark { dark_normal } else { light_normal }
                 };
+                let selected_val = if is_selected { 1.0f64 } else { 0.0f64 };
                 let text_color = if is_dark { dark_text } else { light_text };
 
-                inner.view.view(item_path).apply_over(cx, live!{ draw_bg: { color: (bg_color) } });
+                inner.view.view(item_path).apply_over(cx, live!{ draw_bg: { color: (bg_color), selected: (selected_val) } });
                 inner.view.label(label_path).apply_over(cx, live!{ draw_text: { color: (text_color) } });
             }
 
@@ -931,5 +932,31 @@ impl ProvidersPanelRef {
         if let Some(mut inner) = self.borrow_mut() {
             inner.select_provider_internal(cx, provider_id);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_providers_panel_action_selected_carries_id() {
+        let action = ProvidersPanelAction::Selected("openai".to_string());
+        match action {
+            ProvidersPanelAction::Selected(id) => assert_eq!(id, "openai"),
+            _ => panic!("Expected Selected variant"),
+        }
+    }
+
+    #[test]
+    fn test_providers_panel_action_none_is_default() {
+        let action = ProvidersPanelAction::None;
+        assert!(matches!(action, ProvidersPanelAction::None));
+    }
+
+    #[test]
+    fn test_providers_panel_action_add_provider() {
+        let action = ProvidersPanelAction::AddProviderClicked;
+        assert!(matches!(action, ProvidersPanelAction::AddProviderClicked));
     }
 }


### PR DESCRIPTION
## 📋 Summary

Fix the "sticky highlights" bug in the providers panel where clicking multiple provider items (e.g., OpenAI → DeepSeek → NVIDIA) accumulated highlight states instead of showing only the currently selected provider. The root cause was that select_provider_internal() and update_dark_mode() were not setting the shader's instance selected variable, which the ProviderItem pixel shader reads to render the selected background color. This PR adds selected: 0.0 / selected: 1.0 to the relevant apply_over() calls, ensuring only one provider is visually highlighted at a time.

## 🔗 Related Issues

Closes #58 

Related to #58 

---

## 🧠 Context

The ProviderItem widget uses a custom Makepad shader with instance selected, instance hover, and instance dark_mode variables. The shader's pixel() function computes the background color from these instance variables:
```
fn pixel(self) -> vec4 {
    let base = mix(normal, hover_color, self.hover);
    return mix(base, selected_color, self.selected);
}
```
However, select_provider_internal() was only setting draw_bg: { color: (...) } — a property the shader never reads. This meant the shader's selected instance variable was never cleared on previously-selected items, causing all clicked items to stay highlighted. Custom provider items were already correctly using selected: 0.0/1.0, so only the four built-in providers (OpenAI, DeepSeek, Alibaba Cloud, NVIDIA) were affected.


## 🛠️ Changes

-Added selected: 0.0, hover: 0.0 to the reset loop in select_provider_internal() so all built-in items have their shader state cleared before the new selection
-Added selected: 1.0 to each built-in provider's selection branch so the shader renders the selected background
-Added selected: (selected_val) to the update_dark_mode() loop so dark mode toggling preserves correct selection state
-Added 3 unit tests for the ProvidersPanelAction enum (follows existing #[cfg(test)] module pattern)


---

## 🧪 How you Tested
1. cargo check -p mofa-settings — compiles with no new warnings
2. cargo test -p mofa-settings — 27 tests pass, 0 failures
3. cargo clippy -p mofa-settings — no new warnings (all pre-existing)
4. Manual testing: cargo run --bin mofa-studio → Settings → Providers panel:
Click OpenAI → only OpenAI highlights
Click DeepSeek → only DeepSeek highlights, OpenAI clears
Click NVIDIA → only NVIDIA highlights, DeepSeek clears
Toggle dark mode → selected provider stays correctly highlighted

---

## 📸 Screenshots / Logs (if applicable)

<!-- CLI output, logs, or UI screenshots -->
[Screencast From 2026-03-05 00-25-45.webm](https://github.com/user-attachments/assets/0317a332-efd6-4012-b4d5-106426b1816b)


---

## ⚠️ Breaking Changes

- [x] No breaking changes
- [ ] Breaking change (describe below)

If breaking:

---

## 🧹 Checklist

### Code Quality
- [x] Code follows Rust idioms and project conventions
- [x] `cargo fmt` run
- [x] `cargo clippy` passes without warnings

### Testing
- [x] Tests added/updated
- [x] `cargo test` passes locally without any error

### Documentation
- [x] Public APIs documented
- [ ] README / docs updated (if needed)

### PR Hygiene
- [x] PR is small and focused (one logical change)
- [x] Branch is up to date with `main`
- [x] No unrelated commits
- [x] Commit messages explain **why**, not only **what**

---

## 🚀 Deployment Notes (if applicable)

<!-- migrations, config changes, env vars, rollout steps -->
No migrations, config changes, or environment variable changes required. Drop-in fix.


---

## 🧩 Additional Notes for Reviewers

<!-- Anything reviewers should pay attention to -->
The fix preserves all existing color logic (color: (normal_color) / color: (selected_color)) exactly as-is. The only additions are the selected and hover instance variables in the same apply_over() calls, which the shader's pixel() function actually reads. This is the minimal change needed to fix the glitch without altering any design decisions around colors or theming.