### PR TITLE
fix: remove shared solve-group from environments

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -95,10 +95,9 @@ mlx-audio = "*"
 
 [environments]
 # Default environment (CPU-only, cross-platform)
-default = { solve-group = "default" }
 
 # macOS with MLX acceleration (Apple Silicon)
-macos-mlx = { features = ["macos-mlx"], solve-group = "default" }
+macos-mlx = { features = ["macos-mlx"] }
 
 # =============================================================================
 # TASKS


### PR DESCRIPTION
Fixes #64 

##  Summary

Fixes a cross-platform dependency resolution issue in `pixi.toml` that caused `pixi install` and `pixi run` to fail on Windows and Linux.

The problem occurred because the `default` environment and the `macos-mlx` environment shared the same `solve-group`, which caused Pixi to attempt resolving macOS-specific dependencies on non-macOS systems.

Removing the shared `solve-group` allows Pixi to resolve each environment independently.



##  Context

The `default` environment is intended to be cross-platform, while the `macos-mlx` environment contains Apple Silicon–specific dependencies such as `mlx-audio`.

Both environments were configured with:

```
solve-group = "default"
```

When environments share a `solve-group`, Pixi generates a single dependency resolution for them. This caused Pixi to attempt resolving macOS-only dependencies on Windows and Linux, resulting in the following error:

```
failed to solve the pypi requirements of environment 'default' for platform 'osx-arm64'
```



## Changes

- Removed `solve-group = "default"` from the `default` environment
- Removed `solve-group = "default"` from the `macos-mlx` environment
- Allowed Pixi to resolve environments independently

No dependency versions or packages were changed.



##  How you Tested

1. Ran `pixi install` on a non-macOS system
2. Verified dependency resolution completes successfully
3. Ran `pixi run` to confirm the project builds and runs correctly



##  Breaking Changes

- [x] No breaking changes
- [ ] Breaking change (describe below)




### Testing
- [x] Verified `pixi install` and `pixi run` work correctly

### PR Hygiene
- [x] PR is small and focused
- [x] No unrelated commits


## 🧩 Additional Notes for Reviewers

This change only affects dependency resolution behavior in Pixi and improves cross-platform compatibility without modifying any dependencies.