### PR TITLE
feat(widgets): add reusable ChatBubble widget with role support

### DIFF
--- a/mofa-widgets/WIDGET_GUIDE.md
+++ b/mofa-widgets/WIDGET_GUIDE.md
@@ -10,6 +10,7 @@ Shared reusable UI components for MoFA Studio applications built on the Makepad 
 - [ParticipantPanel](#participantpanel)
 - [LogPanel](#logpanel)
 - [BufferGauge](#buffergauge)
+- [ChatBubble](#chatbubble)
 - [AudioPlayer](#audioplayer)
 - [App Traits](#app-traits)
 
@@ -31,7 +32,7 @@ impl LiveRegister for App {
 }
 ```
 
-### Import in live_design!
+### Import in live_design
 
 ```rust
 live_design! {
@@ -40,6 +41,7 @@ live_design! {
     use mofa_widgets::participant_panel::ParticipantPanel;
     use mofa_widgets::log_panel::LogPanel;
     use mofa_widgets::led_gauge::BufferGauge;
+    use mofa_widgets::chat_bubble::ChatBubble;
 }
 ```
 
@@ -95,6 +97,7 @@ live_design! {
 ### Color Palettes
 
 Full Tailwind-style palettes (50-900 shades):
+
 - `SLATE_*` - Cool gray for backgrounds
 - `GRAY_*` - Neutral gray for text
 - `BLUE_*`, `INDIGO_*` - Primary colors
@@ -122,6 +125,7 @@ draw_bg: {
 ```
 
 Update at runtime:
+
 ```rust
 widget.apply_over(cx, live!{ draw_bg: { dark_mode: 1.0 } });
 ```
@@ -401,6 +405,61 @@ live_design! {
 
 ---
 
+## ChatBubble
+
+Reusable chat message bubble with role-based styling for user, assistant, and system messages.
+
+### Features
+
+- Role-specific colors and text colors
+- Automatic text wrapping
+- Configurable padding and margins
+
+### Usage
+
+```rust
+live_design! {
+    use mofa_widgets::chat_bubble::ChatBubble;
+
+    ChatView = <View> {
+        user_bubble = <ChatBubble> {
+            role: 0.0,
+            text: "Hello, how can I help you?"
+        }
+        assistant_bubble = <ChatBubble> {
+            role: 1.0,
+            text: "I'm here to assist with your questions."
+        }
+        system_bubble = <ChatBubble> {
+            role: 2.0,
+            text: "System message: Connection established"
+        }
+    }
+}
+```
+
+### Updating Content
+
+Set role and text dynamically:
+
+```rust
+// Update bubble
+self.view.view(ids!(bubble)).apply_over(cx, live!{
+    role: 1.0,
+    text: "New response"
+});
+```
+
+### Roles
+
+| Role | Background | Text Color | Description |
+|------|------------|------------|-------------|
+| User | Blue | White | User messages |
+| Assistant | Gray | Dark | AI responses |
+| System | Yellow | Dark | System notifications |
+
+---
+
 ## AudioPlayer
 
 Thread-safe circular buffer audio playback using cpal.
@@ -509,6 +568,7 @@ impl TimerControl for MyWidgetRef {
 ```
 
 **Why use TimerControl?**
+
 - Prevents resource waste on hidden widgets
 - Avoids stale timer callbacks
 - Makepad doesn't auto-cleanup timers
@@ -678,6 +738,7 @@ fn pixel(self) -> vec4 {
 ### Lexer Issues
 
 Some hex values are adjusted to avoid Rust lexer conflicts:
+
 - `#1e293b` → `#1f293b` (because `1e` looks like scientific notation)
 - `#4ade80` → `#4adf80` (because `de` is a digit sequence)
 

--- a/mofa-widgets/src/chat_bubble.rs
+++ b/mofa-widgets/src/chat_bubble.rs
@@ -1,0 +1,148 @@
+//! # Chat Bubble Widget
+//!
+//! A reusable chat bubble component for displaying messages with role-based styling.
+//! Supports user, assistant, and system message types with appropriate visual differentiation.
+//!
+//! ## Features
+//!
+//! - **Role Support**: User (blue), Assistant (gray), System (yellow)
+//! - **Responsive Layout**: Bubbles adapt to content width with max constraints
+//! - **Theme Integration**: Uses centralized color palette
+//!
+//! ## Usage
+//!
+//! ```rust,ignore
+//! live_design! {
+//!     use mofa_widgets::chat_bubble::ChatBubble;
+//!
+//!     ChatView = <View> {
+//!         user_msg = <ChatBubble> {
+//!             role: 0.0,
+//!             text: "Hello, how are you?"
+//!         }
+//!         assistant_msg = <ChatBubble> {
+//!             role: 1.0,
+//!             text: "I'm doing well, thank you!"
+//!         }
+//!     }
+//! }
+//! ```
+//!
+//! ## Updating Content
+//!
+//! Set the role and text via instance variables:
+//!
+//! ```rust,ignore
+//! // Update bubble content
+//! self.view.view(ids!(bubble)).apply_over(cx, live!{
+//!     role: 1.0,
+//!     text: "New message content"
+//! });
+//! ```
+//!
+//! ## Roles
+//!
+//! - **0.0 (User)**: Blue background, white text
+//! - **1.0 (Assistant)**: Gray background, dark text
+//! - **2.0 (System)**: Yellow background, dark text
+
+use makepad_widgets::*;
+
+live_design! {
+    use link::theme::*;
+    use link::shaders::*;
+    use link::widgets::*;
+
+    // Import colors from theme
+    use crate::theme::ACCENT_BLUE;
+    use crate::theme::GRAY_100;
+    use crate::theme::ACCENT_YELLOW;
+    use crate::theme::TEXT_PRIMARY;
+    use crate::theme::TEXT_PRIMARY_DARK;
+
+    pub ChatBubble = {{ChatBubble}} <View> {
+        width: Fill,
+        height: Fit,
+        margin: {top: 4, bottom: 4}
+        // role: 0 = user, 1 = assistant, 2 = system
+        instance role: 0.0
+        instance text: ""
+
+        draw_bg: {
+            role: (role)
+            instance role: 0.0
+
+            fn get_bg_color(self) -> vec4 {
+                if self.role < 0.5 {
+                    return (ACCENT_BLUE);
+                }
+                if self.role < 1.5 {
+                    return (GRAY_100);
+                }
+                return (ACCENT_YELLOW);
+            }
+
+            fn pixel(self) -> vec4 {
+                let bg_color = self.get_bg_color();
+                return vec4(bg_color.r, bg_color.g, bg_color.b, bg_color.a);
+            }
+        }
+
+        bubble_container = <View> {
+            width: Fill,
+            height: Fit,
+            padding: 12,
+            spacing: 0,
+
+            align: {
+                x: 0.0, // Left align by default
+                y: 0.5
+            }
+
+            text_label = <Label> {
+                width: Fill,
+                height: Fit,
+                draw_text: {
+                    role: (role)
+                    instance role: 0.0
+
+                    fn get_text_color(self) -> vec4 {
+                        if self.role < 0.5 {
+                            return (TEXT_PRIMARY); // White text on blue
+                        }
+                        return (TEXT_PRIMARY_DARK);
+                    }
+
+                    text_style: {
+                        font_size: 14.0,
+                        line_spacing: 1.2,
+                    }
+                    color: (TEXT_PRIMARY_DARK)
+                    wrap: Word
+
+                    fn pixel(self) -> vec4 {
+                        let color = self.get_text_color();
+                        return vec4(color.r, color.g, color.b, color.a);
+                    }
+                }
+                text: (text)
+            }
+        }
+    }
+}
+
+#[derive(Live, LiveHook, Widget)]
+pub struct ChatBubble {
+    #[deref]
+    view: View,
+}
+
+impl Widget for ChatBubble {
+    fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        self.view.handle_event(cx, event, scope);
+    }
+
+    fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
+        self.view.draw_walk(cx, scope, walk)
+    }
+}

--- a/mofa-widgets/src/lib.rs
+++ b/mofa-widgets/src/lib.rs
@@ -28,6 +28,7 @@
 //! - [`waveform_view`] - Real-time audio waveform visualization
 //! - [`log_panel`] - Scrollable Markdown log display
 //! - [`led_gauge`] - LED-style bar gauge for levels
+//! - [`chat_bubble`] - Chat message bubble with role support
 //! - [`audio_player`] - Audio playback engine
 //!
 //! ## Theme System
@@ -76,6 +77,7 @@
 
 pub mod app_trait;
 pub mod audio_player;
+pub mod chat_bubble;
 pub mod led_gauge;
 pub mod log_panel;
 pub mod participant_panel;


### PR DESCRIPTION
## Summary
Adds a reusable  widget to  for chat UIs with role-based styling.

## Changes
- add 
- register module in 
- document usage in 

## Roles
-  = user (blue background, white text)
-  = assistant (gray background, dark text)
-  = system (yellow background, dark text)

## Notes
- Build/test validation could not be run in this container because  is unavailable in PATH.
